### PR TITLE
Fix GCC build test/ (force use c++11 in cmake)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,8 @@
 
 find_package(Qt5Test REQUIRED)
 
+add_definitions(-std=c++11)
+
 add_executable(testrunner testrunner.cpp)
 
 target_link_libraries(testrunner Qt5::Test)


### PR DESCRIPTION
On Ubuntu 16.04.2 LTS Xenial, compilation in directory test failed.
>  In file included from /usr/local/share/qmlfmt/test/testrunner.cpp:29:0:
> /usr/local/share/qmlfmt/test/testrunner.h:41:10: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
>      std::unique_ptr<QProcess> m_process;
>           ^
> /usr/local/share/qmlfmt/test/testrunner.h:37:61: error: ‘nullptr’ was not declared in this scope
>      TestRunner(const QString& qmlfmtPath, QObject *parent = nullptr);
>                                                              ^
> /usr/local/share/qmlfmt/test/testrunner.cpp: In function ‘int main(int, char**)’:
> /usr/local/share/qmlfmt/test/testrunner.cpp:37:40: error: call to ‘TestRunner::TestRunner(const QString&, QObject*)’ uses the default argument for parameter 2, which is not yet defined
>      TestRunner tc(app.arguments().at(1));
>                                         ^
> /usr/local/share/qmlfmt/test/testrunner.cpp: In constructor ‘TestRunner::TestRunner(const QString&, QObject*)’:
> /usr/local/share/qmlfmt/test/testrunner.cpp:49:20: warning: extended initializer lists only available with -std=c++11 or -std=gnu++11
>          QStringList{ "in_*.qml" },
> 
> [...]

So I force to use c++11 in cmake of directory test and it works!