### PR TITLE
Print error messages to stderr instead of stdout

### DIFF
--- a/qmlfmt.cpp
+++ b/qmlfmt.cpp
@@ -64,6 +64,7 @@ namespace {
     int handle(QIODevice& input, const QString& path)
     {
         QTextStream qstdout(stdout);
+        QTextStream qstderr(stderr);
         const QString source = QString::fromUtf8(input.readAll());
         const QmlJS::Dialect dialect = QmlJS::ModelManagerInterface::guessLanguageOfFile(path);
 
@@ -76,11 +77,11 @@ namespace {
             {
                 for (const QmlJS::DiagnosticMessage& msg : document->diagnosticMessages())
                 {
-                    qstdout << (msg.isError() ? "Error:" : "Warning:");
+                    qstderr << (msg.isError() ? "Error:" : "Warning:");
 
-                    qstdout << msg.loc.startLine << ':' << msg.loc.startColumn << ':';
+                    qstderr << msg.loc.startLine << ':' << msg.loc.startColumn << ':';
 
-                    qstdout << ' ' << msg.message << "\n";
+                    qstderr << ' ' << msg.message << "\n";
                 }
             }
             return 1;
@@ -156,7 +157,7 @@ namespace {
         }
         else
         {
-            QTextStream(stdout) << "Path is not valid file or directory\n";
+            QTextStream(stderr) << "Path is not valid file or directory\n";
             return 1;
         }
 
@@ -193,13 +194,13 @@ int main(int argc, char *argv[])
     // validate arguments
     if ((parser.isSet(overwriteOption) || parser.isSet(listOption)) && parser.positionalArguments().count() == 0)
     {
-        QTextStream(stdout) << "Cannot combine -" << overwriteOption.names().first() << " and -" << listOption.names().first()
+        QTextStream(stderr) << "Cannot combine -" << overwriteOption.names().first() << " and -" << listOption.names().first()
             << " with standard input\n";
         return 1;
     }
     else if (parser.isSet(diffOption) + parser.isSet(overwriteOption) + parser.isSet(listOption) > 1)
     {
-        QTextStream(stdout) << "-" << diffOption.names().first() << ", -" << overwriteOption.names().first() << " and -" <<
+        QTextStream(stderr) << "-" << diffOption.names().first() << ", -" << overwriteOption.names().first() << " and -" <<
             listOption.names().first() << " are mutually exclusive\n";
         return 1;
     }

--- a/test/data/in_error-stderr.qml
+++ b/test/data/in_error-stderr.qml
@@ -1,0 +1,3 @@
+// MyItem.qml
+import QtQuick 2.7
+Item {

--- a/test/data/out_error-stderr.qml
+++ b/test/data/out_error-stderr.qml
@@ -1,0 +1,1 @@
+Error:3:7: Expected token "}".

--- a/test/data/out_error.qml
+++ b/test/data/out_error.qml
@@ -1,1 +1,0 @@
-Error:3:7: Expected token "}".

--- a/test/testrunner.cpp
+++ b/test/testrunner.cpp
@@ -81,7 +81,7 @@ QString TestRunner::readFile(const QString & fileName)
     return QString(inputFile.readAll());
 }
 
-QString TestRunner::readStdOut()
+QString TestRunner::readStream(const QString & inputFileName)
 {
     if (!m_process->waitForFinished())
     {
@@ -89,7 +89,14 @@ QString TestRunner::readStdOut()
         return QString();
     }
 
-    QString output = QString::fromUtf8(m_process->readAllStandardOutput()).replace("\r", "");
+    QString output;
+
+    if (inputFileName.endsWith("-stderr.qml")) {
+      output = QString::fromUtf8(m_process->readAllStandardError()).replace("\r", "");
+    }
+    else
+      output = QString::fromUtf8(m_process->readAllStandardOutput()).replace("\r", "");
+
     return output;
 }
 
@@ -118,7 +125,7 @@ void TestRunner::PrintWithDifferences()
 
     m_process->setArguments({ input, "-l", "-e" });
     m_process->start();
-    QString formatted = readStdOut();
+    QString formatted = readStream(input);
     QCOMPARE(hasError ? readFile(expected) : input + "\n", formatted);
 }
 
@@ -129,7 +136,7 @@ void TestRunner::DiffWithFormatted()
 
     m_process->setArguments({ input, "-d", "-e" });
     m_process->start();
-    QString diff = readStdOut();
+    QString diff = readStream(input);
     bool identicalFiles = readFile(input) == readFile(expected);
     QCOMPARE(input.size() == 0, identicalFiles);
 }
@@ -159,7 +166,7 @@ void TestRunner::FormatFileToStdOut()
 
     m_process->setArguments({ input , "-e" });
     m_process->start();
-    QString formattedQml = readStdOut();
+    QString formattedQml = readStream(input);
     QString expectedQml = readFile(expected);
     QCOMPARE(expectedQml, formattedQml);
 }
@@ -175,6 +182,6 @@ void TestRunner::FormatStdInToStdOut()
 
     m_process->write(readFile(input).toUtf8());
     m_process->closeWriteChannel();
-    QString formatted = readStdOut();
+    QString formatted = readStream(input);
     QCOMPARE(formatted, readFile(expected));
 }

--- a/test/testrunner.h
+++ b/test/testrunner.h
@@ -46,7 +46,8 @@ private:
 
     QString readFile(const QString& fileName);
 
-    QString readStdOut();
+    /* Read stderr if inputFileName has suffix '-stderr', from stdout otherwise */
+    QString readStream(const QString& inputFileName = QString());
 
     QString getTemporaryFileName();
 


### PR DESCRIPTION
This allows to distinguish between program output when run without errors
(meaning that it successfully produced reformatted code) and program
output when encountering errors.

The main cause for this change is the following behavior: running
`qmlfmt -e` on a file not containing errors will print the reformatted file to
stdout, but doing the same on a file containing errors also prints these
to stdout. I think it's helpful to distinguish, and then leave it to the
users to redirect the output to their taste.