### PR TITLE
add homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ qmlfmt - command line application that formats QML files
 If you are on *macOS* and using [Homebrew](https://brew.sh), you can install *qmlfmt* this way:
 
 ```
-brew tap martindelille/tap
-brew install qmlfmt
+brew install martindelille/tap/qmlfmt
 ```
 
 ## Build instructions

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 # qmlfmt
 qmlfmt - command line application that formats QML files
 
+## Install via Homebrew
+
+If you are on *macOS* and using [Homebrew](https://brew.sh), you can install *qmlfmt* this way:
+
+```
+brew tap martindelille/tap
+brew install qmlfmt
+```
+
 ## Build instructions
 Requires
 - CMake 3.1 or later


### PR DESCRIPTION
I create a homebrew formula for qmlfmt for macOS user.

The formula won't be accepted yet in the homebrew core tap because it isn't popular enough yet: https://github.com/Homebrew/homebrew-core/pull/41200#issuecomment-504387354

The only problem I have is that the version is not displayed when I set it like in the `.travis.yml` file:

```
cmake .. -DQMLFMT_VERSION:STRING=1.0.85
-- The C compiler identification is AppleClang 9.0.0.9000039
-- The CXX compiler identification is AppleClang 9.0.0.9000039
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    QMLFMT_VERSION


-- Build files have been written to: /Users/martin/dev/clone/qmlfmt/build
```
