### PR TITLE
replaced submodule source with main repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "qt-creator"]
 	path = qt-creator
-	url = https://github.com/qt-creator/qt-creator
+	url = https://code.qt.io/cgit/qt-creator/qt-creator.git
 	branch = 4.10


### PR DESCRIPTION
Building the project as described in the readme failed due to:
```
root@c8329735c78c:~/qmlfmt# git submodule update --init --recursive
Submodule 'qt-creator' (https://github.com/qt-creator/qt-creator) registered for path 'qt-creator'
Cloning into '/root/qmlfmt/qt-creator'...
Submodule path 'qt-creator': checked out '40fc771a519b5abfa44a2ec3a7d77f70f765871f'
Submodule 'qbs' (https://github.com/qbs/qbs.git) registered for path 'qt-creator/src/shared/qbs'
Submodule 'perfparser' (https://github.com/qt-creator/perfparser.git) registered for path 'qt-creator/src/tools/perfparser'
Cloning into '/root/qmlfmt/qt-creator/src/shared/qbs'...
Username for 'https://github.com': Cloning into '/root/qmlfmt/qt-creator/src/tools/perfparser'...
```
I managed to reproduce this error on: 
- NixOS 19.09
- Debian Buster

This seems to be a problem of the github mirror, after replacing the qt-creator dependency with the main repo everything works fine.
