### PR TITLE
Minor issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "qt-creator"]
 	path = qt-creator
-	url = https://code.qt.io/cgit/qt-creator/qt-creator.git
+	url = https://github.com/qt-creator/qt-creator
 	branch = 4.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,4 @@ deploy:
 branches:
   only:
     - master
+    - /\d+\.\d+\.\d+/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requires
 
 After checking out the repository, `cd` to it and run:
 
-    git submodule update --init --recursive
+    git submodule update --init qt-creator
     mkdir build
     cd build
     cmake ..


### PR DESCRIPTION
- Revert back to using Github mirror for Qt Creator, as the Qt repo is unstable.
- Update README to not use recursive submodule init.
- Allow deploying binaries from travis on tagged builds.