### PR TITLE
Continue formatting when source file is already formatted

### DIFF
--- a/qmlfmt.cpp
+++ b/qmlfmt.cpp
@@ -48,7 +48,7 @@ int QmlFmt::InternalRun(QIODevice& input, const QString& path)
 
     QmlJS::Document::MutablePtr document = QmlJS::Document::create(path, dialect);
     document->setSource(source);
-    document->parse();      
+    document->parse();
     if (!document->diagnosticMessages().isEmpty())
     {
         if (this->m_options.testFlag(Option::PrintError))
@@ -66,8 +66,6 @@ int QmlFmt::InternalRun(QIODevice& input, const QString& path)
     }
 
     const QString reformatted = QmlJS::reformat(document, m_indentSize, m_tabSize);
-    if (source == reformatted)
-        return 0;
 
     if (this->m_options.testFlag(Option::ListFileName))
     {

--- a/test/testrunner.cpp
+++ b/test/testrunner.cpp
@@ -189,8 +189,7 @@ void TestRunner::FormatFileToStdOut()
     m_process->setArguments({ input , "-e" });
     m_process->start();
     QString output = readOutputStream(hasError);
-    bool identicalFiles = !hasError && readFile(input) == readFile(expected);
-    QCOMPARE(output, identicalFiles ? "" : readFile(expected));
+    QCOMPARE(output, readFile(expected));
 }
 
 void TestRunner::FormatStdInToStdOut()
@@ -206,8 +205,7 @@ void TestRunner::FormatStdInToStdOut()
     m_process->write(readFile(input).toUtf8());
     m_process->closeWriteChannel();
     QString output = readOutputStream(hasError);
-    bool identicalFiles = !hasError && readFile(input) == readFile(expected);
-    QCOMPARE(output, identicalFiles ? "" : readFile(expected));
+    QCOMPARE(output, readFile(expected));
 }
 
 void TestRunner::PrintFolderWithDifferences()


### PR DESCRIPTION
Before my changes, when executing qmlfmt from the vim text editor (using a config like the one listed below,) the file ends up losing all it's content.    

    function! FormatMyCode() abort
         :%!qmlfmt % -i 2
    endfunction
    augroup mygroup
        autocmd!
        autocmd BufWrite *.qml call FormatMyCode()
    augroup end

Every other formatter seems to work fine with this approach for that editor so I don't think the problem lies there. Thus my commit and it's brief message.